### PR TITLE
Fix tests for keysight_e4980a

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -292,16 +292,15 @@ class KeysightE4980A(VisaInstrument):
 
         self.add_parameter(
             "meas_time_mode",
-            initial_value="medium",
             val_mapping={"short": "SHOR", "medium": "MED", "long": "LONG"},
             parameter_class=GroupParameter
         )
 
         self.add_parameter(
             "averaging_rate",
-            initial_value=1,
             vals=Ints(1, 256),
             parameter_class=GroupParameter,
+            get_parser=int,
             docstring="Averaging rate for the measurement."
         )
 
@@ -338,7 +337,6 @@ class KeysightE4980A(VisaInstrument):
             "_correction",
             Correction4980A(self, "correction")
         )
-
         self.connect_message()
 
     @property

--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -189,8 +189,9 @@ class KeysightE4980A(VisaInstrument):
 
         idn = self.IDN.get()
 
-        self.has_firmware_a_02_10_or_above = LooseVersion(idn["firmware"]) >=\
-                                             LooseVersion("A.02.10")
+        self.has_firmware_a_02_10_or_above = (
+                LooseVersion(idn["firmware"]) >= LooseVersion("A.02.10")
+        )
 
         self.has_option_001 = '001' in self._options()
         self._dc_bias_v_level_range: Union[Numbers, Enum]

--- a/qcodes/tests/drivers/test_keysight_e4980a.py
+++ b/qcodes/tests/drivers/test_keysight_e4980a.py
@@ -7,9 +7,8 @@ import qcodes.instrument.sims as sims
 VISALIB = sims.__file__.replace('__init__.py', 'Keysight_E4980A.yaml@sim')
 
 
-# pylint: disable=redefined-outer-name
-@pytest.fixture
-def driver():
+@pytest.fixture(name="driver")
+def _make_driver():
     instr = E4980A.KeysightE4980A('E4980A',
                                   address="GPIB::1::INSTR",
                                   visalib=VISALIB)

--- a/qcodes/tests/drivers/test_keysight_e4980a.py
+++ b/qcodes/tests/drivers/test_keysight_e4980a.py
@@ -32,8 +32,8 @@ def test_raise_error_for_volt_level_query_when_signal_set_as_current(driver):
 
 
 def test_voltage_level_set_method(driver):
-    driver.voltage_level(2)
-    assert driver.voltage_level() == 2
+    driver.voltage_level(3)
+    assert driver.voltage_level() == 3
 
 
 def test_signal_mode_parameter(driver):

--- a/qcodes/tests/drivers/test_keysight_e4980a.py
+++ b/qcodes/tests/drivers/test_keysight_e4980a.py
@@ -32,8 +32,8 @@ def test_raise_error_for_volt_level_query_when_signal_set_as_current(driver):
 
 
 def test_voltage_level_set_method(driver):
-    driver.voltage_level(3)
-    assert driver.voltage_level() == 3
+    driver.voltage_level(2)
+    assert driver.voltage_level() == 2
 
 
 def test_signal_mode_parameter(driver):


### PR DESCRIPTION
Avoid initial values for 2 parameters in a group. 

Setting the initial value will cause the driver to write to the instrument. This gives an error in the tests since the
yaml file does not implement the relevant command. @Akshita07 If this is really intentional we can instead add this to the yaml file.

Also:

Some small formatting cleanups
Rework fixture such that we don't have to suppress a pylint warning
add a needed get_parser